### PR TITLE
CorrectCancelBtn

### DIFF
--- a/GUI/FormBug.cs
+++ b/GUI/FormBug.cs
@@ -162,6 +162,7 @@ namespace GUI
         {
             dgvMessages.DataSource = messageSearchTool.SearchByBugId(bugId);
             richTxtLogs.Text = logSearchTool.SearchLogByBugId(bugId);
+            bugInfo = bugSearchTool.SearchBugsById(bugId);
             BackToReadOnly();
 
         }
@@ -221,10 +222,13 @@ namespace GUI
                 logsAddTool.addBugUpdateLog(bugId);
                 reset();
 
-                // Return to read only and reset selection form
+                // Change last edit date and reset form 
                 txtLastEditDate.Text = DateTime.Now.ToShortDateString();
+                reset();
+
+                //reset selection form
                 selectionForm.reset();
-                BackToReadOnly();
+                
             }
         }
 


### PR DESCRIPTION
The cancel button used to go back to the opening state of the form, ignoring possible saved changes done in between, this branch corrects it.
Now the user can do that: 
1 - open bug form -> 2 - edit -> 3 - make a change -> 4 - save -> 5 - edit -> 6- cancel
The form will be back in state between 4 and 5 and not 1 like before